### PR TITLE
Refine pipeline (modularity and decisions)

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -19,6 +19,7 @@ Read across the PDB to find similar binding sites and their associated molecules
    - Look at output molecule library
    - Notebook: [`molecule_library.ipynb`](https://github.com/dominiquesydow/covid19/blob/master/notebooks/molecule_library.ipynb)
    
+Note: This pipeline could be automatized before (1.) and after (2.-4.) the manual ProBis step.
    
 ## Data
 


### PR DESCRIPTION
## Description
The `master` branch contains working pipeline from input (multiple target complexes) to output (molecule library). This pipeline needs refinement - technically and contentwise.

## Todos

### Target and binding site definition
- [ ] Do we like the binding site definition parameter choices (`distance_cutoff = 15` and `coverage_cutoff = 0.5`)? Smaller distance, higher coverage?

### Similar binding sites / proteins
- [ ] Problem with ProBis result download for full protein search: Cannot download *ProBis protein table* (`Request-URI Too Long`). Can we fix this? (Do we have to or do we stick to pocket-specific search anyways?)
- [ ] Currently, we only use similar proteins from the *ProBis protein table*. Can we also make use of the *ProBis ligand tables*? Check out what this dataset means in detail and how it can be used.
- [ ] Do we want to filter the hits from the `ProBis protein table* (e.g. by confidence)? Currently, we simply take all hits for the downstream pipeline.

### Active molecules against similar proteins
- [ ] Do we like the ChEMBL filtering steps (e.g. `pic50_cutoff` or using only targets of type `SINGLE PROTEIN`)?
- [ ] Technical: Currently, when we query ChEMBL with multiple IDs (i.e. a list of UniProt IDs, target IDs, or molecule IDs), we loop over the list and query ChEMBL for each list element individually ([notebook](https://github.com/dominiquesydow/covid19/blob/master/notebooks/chembl_utils.py)). However, the `chembl_webresource_client` does offer "bulk" queries - these seemed to be very slow for me but it is possible that the cause for this behaviour was in one of the downstream steps (e.g. `pandas.DataFrame.from_records`). Check again if the "bulk" queries can be used.
  - `TARGET_API.get(target_components__accession)` > ?
  - `BIOACTIVITY_API.filter(target_chembl_id)` > `BIOACTIVITY_API.filter(target_chembl_id__in)`
  - `MOLECULE_API.filter(molecule_chembl_id)` > `MOLECULE_API.filter(molecule_chembl_id__in)`

### Pipeline automization
Currently, the pipeline consists of 3 notebooks, i.e. (i) binding site definition, (ii) binding site comparison, including manual ProBis interaction, and (iii) molecule library generation from similar proteins using ChEMBL.  
- [ ] These steps could be automatized in a python script (for multiple runs with different parameters, pooling of results?). 
- [ ] Since I will need these steps also for other projects: 
  - Step (i) needs to be independent from input structures: Currently, ligands in all structures must have the same name - make this more generic.
  - Step (ii) needs to be modular to be able to use any method: Do we need here method-specific modules?
  - Step (iii) is fine as-is: Input UniProt IDs > output molecule library.

## Status
- [ ] Ready to go